### PR TITLE
Added a `get_or_set` method that sets if needed.

### DIFF
--- a/lib/filecache.rb
+++ b/lib/filecache.rb
@@ -54,6 +54,17 @@ class FileCache
     end
   end
   
+  # Return the value for the specified key from the cache if the key exists in the
+  # cache, otherwise set the value returned by the block. Returns the value if found
+  # or the value from calling the block that was set.
+  def get_or_set(key)
+    value = get(key)
+    return value if value
+    value = yield
+    set(key, value)
+    value
+  end
+
   # Delete the value for the given key from the cache
   def delete(key)
     FileUtils.rm(get_path(key))


### PR DESCRIPTION
### What

Added a `get_or_set` method that sets if needed, otherwise returns what's cached.
### Why

I often find when using this library I'm writing code in the same pattern:

``` ruby
value = cache.get(key)
if value.nil?
  value = ...
  cache.set(key, value)
end
```
### Usage

``` ruby
value = cache.get_or_set(key) do
  ...
end
```
